### PR TITLE
feat: Initial tests and fixes for DataService

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -57,4 +57,20 @@ module.exports = {
 
 	// Setup file to mock Roblox environment for Node.js when using VS Code
 	...(isVSCodeJest ? { setupFilesAfterEnv: ["<rootDir>/scripts/js/jest-setup-roblox-mocks.js"] } : {}),
+
+	// modulePaths: ["<rootDir>/places/common/src"], // Replaced by moduleNameMapper
+	moduleNameMapper: {
+		"^server/(.*)$": "<rootDir>/places/common/src/server/$1",
+		"^common/(.*)$": "<rootDir>/places/common/src/$1",
+		// Add a mapping for shared if needed, e.g., from places/common/src/shared
+		"^shared/(.*)$": "<rootDir>/places/common/src/shared/$1",
+		// Mock @flamework/core itself
+		"^@flamework/core$": "<rootDir>/scripts/js/jest-flamework-mock.js",
+		// Mock @rbxts/services
+		"^@rbxts/services$": "<rootDir>/scripts/js/jest-rbxts-services-mock.js",
+		// Mock @rbxts/profile-store
+		"^@rbxts/profile-store$": "<rootDir>/scripts/js/jest-profile-store-mock.js",
+		// Keep .lua mock for any other direct .lua imports if they occur
+		"\\.lua$": "<rootDir>/scripts/js/jest-empty-mock.js",
+	},
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
 				"eslint-plugin-prettier": "^3.4.0",
 				"eslint-plugin-roblox-ts": "^0.0.30",
 				"jest": "^29.7.0",
+				"jest-mock-extended": "^4.0.0",
 				"prettier": "^2.3.2",
 				"rbxts-transformer-flamework": "^1.2.2",
 				"roblox-ts": "^2.3.0",
@@ -6286,6 +6287,21 @@
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
+		"node_modules/jest-mock-extended": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/jest-mock-extended/-/jest-mock-extended-4.0.0.tgz",
+			"integrity": "sha512-7BZpfuvLam+/HC+NxifIi9b+5VXj/utUDMPUqrDJehGWVuXPtLS9Jqlob2mJLrI/pg2k1S8DMfKDvEB88QNjaQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ts-essentials": "^10.0.2"
+			},
+			"peerDependencies": {
+				"@jest/globals": "^28.0.0 || ^29.0.0 || ^30.0.0",
+				"jest": "^24.0.0 || ^25.0.0 || ^26.0.0 || ^27.0.0 || ^28.0.0 || ^29.0.0 || ^30.0.0",
+				"typescript": "^3.0.0 || ^4.0.0 || ^5.0.0"
+			}
+		},
 		"node_modules/jest-pnp-resolver": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
@@ -7953,6 +7969,21 @@
 				"typescript": ">=4.2.0"
 			}
 		},
+		"node_modules/ts-essentials": {
+			"version": "10.1.1",
+			"resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-10.1.1.tgz",
+			"integrity": "sha512-4aTB7KLHKmUvkjNj8V+EdnmuVTiECzn3K+zIbRthumvHu+j44x3w63xpfs0JL3NGIzGXqoQ7AV591xHO+XrOTw==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"typescript": ">=4.5.0"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/ts-jest": {
 			"version": "29.4.0",
 			"resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.0.tgz",
@@ -8092,6 +8123,7 @@
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
 			"integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -12838,6 +12870,15 @@
 				"jest-util": "^29.7.0"
 			}
 		},
+		"jest-mock-extended": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/jest-mock-extended/-/jest-mock-extended-4.0.0.tgz",
+			"integrity": "sha512-7BZpfuvLam+/HC+NxifIi9b+5VXj/utUDMPUqrDJehGWVuXPtLS9Jqlob2mJLrI/pg2k1S8DMfKDvEB88QNjaQ==",
+			"dev": true,
+			"requires": {
+				"ts-essentials": "^10.0.2"
+			}
+		},
 		"jest-pnp-resolver": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
@@ -14043,6 +14084,13 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.3.tgz",
 			"integrity": "sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==",
+			"dev": true,
+			"requires": {}
+		},
+		"ts-essentials": {
+			"version": "10.1.1",
+			"resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-10.1.1.tgz",
+			"integrity": "sha512-4aTB7KLHKmUvkjNj8V+EdnmuVTiECzn3K+zIbRthumvHu+j44x3w63xpfs0JL3NGIzGXqoQ7AV591xHO+XrOTw==",
 			"dev": true,
 			"requires": {}
 		},

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
 		"eslint-plugin-prettier": "^3.4.0",
 		"eslint-plugin-roblox-ts": "^0.0.30",
 		"jest": "^29.7.0",
+		"jest-mock-extended": "^4.0.0",
 		"prettier": "^2.3.2",
 		"rbxts-transformer-flamework": "^1.2.2",
 		"roblox-ts": "^2.3.0",

--- a/places/common/src/server/services/data.service.ts
+++ b/places/common/src/server/services/data.service.ts
@@ -120,7 +120,7 @@ export class DataService implements OnInit {
 
 		// Add all fields from template
 		for (const [key, templateValueInLoop] of pairs(templateTable)) { // Renamed to avoid conflict
-			const currentTemplateValue = templateTable[key]; // Get fresh value
+			const currentTemplateValue = templateValueInLoop; // Use value from iteration
 			const currentUserValue = userDataTable[key];
 
 			if (Array.isArray(currentTemplateValue)) {

--- a/places/common/src/server/services/data.service.ts
+++ b/places/common/src/server/services/data.service.ts
@@ -119,19 +119,34 @@ export class DataService implements OnInit {
 		const userDataTable = userData as Record<string, unknown>;
 
 		// Add all fields from template
-		for (const [key, templateValue] of pairs(templateTable)) {
-			const userValue = userDataTable[key];
-			if (typeOf(templateValue) === "table") {
-				result[key] = this.deepMergeWithTemplate(userValue, templateValue);
+		for (const [key, templateValueInLoop] of pairs(templateTable)) { // Renamed to avoid conflict
+			const currentTemplateValue = templateTable[key]; // Get fresh value
+			const currentUserValue = userDataTable[key];
+
+			if (Array.isArray(currentTemplateValue)) {
+				// If template field is an array, result should also be an array.
+				// User's array takes precedence if it's also an array. Otherwise, use template's array.
+				result[key] = Array.isArray(currentUserValue) ? deepCopy(currentUserValue) : deepCopy(currentTemplateValue);
+			} else if (typeOf(currentTemplateValue) === "table") {
+				// Template field is an object. User's value should also be an object.
+				if (typeOf(currentUserValue) === "table" && !Array.isArray(currentUserValue)) {
+					result[key] = this.deepMergeWithTemplate(currentUserValue, currentTemplateValue);
+				} else {
+					// User value is not a compatible object (e.g., it's primitive, array, or undefined).
+					// Default to template's object structure.
+					result[key] = deepCopy(currentTemplateValue);
+				}
 			} else {
-				result[key] = userValue !== undefined ? userValue : templateValue;
+				// Template field is a primitive. Use user's value if defined, else template's.
+				result[key] = currentUserValue !== undefined ? currentUserValue : currentTemplateValue;
 			}
 		}
 
-		// Add extra fields from userData
+		// Add extra fields from userData (fields not present in the template)
 		for (const [key, userValue] of pairs(userDataTable)) {
 			if (templateTable[key] === undefined) {
-				result[key] = typeOf(userValue) === "table" ? deepCopy(userValue) : userValue;
+				// Only add if it's not in template. If it's a table, deep copy it.
+				result[key] = (typeOf(userValue) === "table") ? deepCopy(userValue) : userValue;
 			}
 		}
 

--- a/places/common/src/shared/utils/deep-copy.ts
+++ b/places/common/src/shared/utils/deep-copy.ts
@@ -1,20 +1,26 @@
 // Deep copy utility for immutable data operations
 
 export function deepCopy<T>(obj: T): T {
-	if (typeOf(obj) !== "table") {
-		return obj;
-	}
+    const objType = typeOf(obj); // typeOf should correctly identify tables/arrays as "table"
 
-	const copy = {} as Record<string, unknown>;
-	const objTable = obj as Record<string, unknown>;
+    if (objType !== "table") { // Handles primitives, functions, nil (as per typeOf mock)
+        return obj;
+    }
 
-	for (const [key, value] of pairs(objTable)) {
-		if (typeOf(value) === "table") {
-			copy[key] = deepCopy(value);
-		} else {
-			copy[key] = value;
-		}
-	}
-
-	return copy as T;
+    // Check if the object is actually a JavaScript array
+    if (Array.isArray(obj)) {
+        const arrCopy = [] as unknown as any[]; // Initialize as an array
+        for (const item of obj as unknown as unknown[]) { // Iterate array elements
+            arrCopy.push(deepCopy(item)); // Push deep copied elements
+        }
+        return arrCopy as T;
+    } else {
+        // It's a table-like object (dictionary)
+        const objCopy = {} as Record<string, unknown>;
+        // Use pairs for iterating, assuming it handles object key-value iteration correctly
+        for (const [key, value] of pairs(obj as Record<string, unknown>)) {
+            objCopy[key as string] = deepCopy(value); // Deep copy nested values
+        }
+        return objCopy as T;
+    }
 }

--- a/places/common/src/tests/data.service.spec.ts
+++ b/places/common/src/tests/data.service.spec.ts
@@ -1,0 +1,347 @@
+// Test suite for DataService
+import { DataService } from "server/services/data.service"; // Using server alias
+import { mock, mockDeep, MockProxy } from "jest-mock-extended";
+import { Players, RunService } from "@rbxts/services";
+import ProfileStore from "@rbxts/profile-store";
+
+// Mock dependencies
+jest.mock("@rbxts/services", () => ({
+    Players: mock<Players>(),
+    RunService: mock<RunService>(),
+}));
+
+jest.mock("@rbxts/profile-store");
+
+describe("DataService", () => {
+    let dataService: DataService;
+    let mockPlayers: MockProxy<Players>;
+    let mockRunService: MockProxy<RunService>;
+    let mockProfileStore: MockProxy<ReturnType<typeof ProfileStore.New>>;
+
+    beforeEach(() => {
+        // Reset mocks before each test
+        mockPlayers = Players as unknown as MockProxy<Players>;
+        mockRunService = RunService as unknown as MockProxy<RunService>;
+        mockProfileStore = (ProfileStore.New as jest.Mock)(expect.anything(), expect.anything()) as unknown as MockProxy<ReturnType<typeof ProfileStore.New>>;
+
+        // Mock RunService.IsStudio() behavior
+        mockRunService.IsStudio.mockReturnValue(false); // Default to non-Studio environment
+
+        dataService = new DataService();
+    });
+
+    it("should be defined", () => {
+        expect(dataService).toBeDefined();
+    });
+
+    describe("onInit", () => {
+        it("should initialize migrations", () => {
+            // Spy on migrations.registerMigration
+            const migrations = require("shared/utils/migrations").migrations; // Use shared alias
+            const registerMigrationSpy = jest.spyOn(migrations, "registerMigration");
+
+            dataService.onInit();
+
+            // Expect registerMigration to have been called at least once
+            expect(registerMigrationSpy).toHaveBeenCalled();
+
+            // Example: Check if a specific migration is registered
+            // This depends on the actual migration logic in DataService
+            expect(registerMigrationSpy).toHaveBeenCalledWith(
+                1,
+                expect.any(Function),
+                "Add missing SlotsApplicable field"
+            );
+
+            // Restore the spy
+            registerMigrationSpy.mockRestore();
+        });
+    });
+
+    // TODO: Add more tests here
+
+    describe("dataCheck", () => {
+        let migrateDataSpy: jest.SpyInstance;
+        const MIGRATIONS_CURRENT_VERSION = require("shared/utils/migrations").migrations.CurrentVersion;
+
+        beforeEach(() => {
+            const migrationsUtil = require("shared/utils/migrations").migrations;
+            migrateDataSpy = jest.spyOn(migrationsUtil, "migrateData")
+                .mockImplementation((data: Record<string, unknown>, currentVersionNumber: number) => {
+                    // Simplified mock: assume it migrates to MIGRATIONS_CURRENT_VERSION
+                    // and applies known changes like SlotsApplicable if going from v1.
+                    const migratedData = { ...data };
+                    if (currentVersionNumber === 1 && MIGRATIONS_CURRENT_VERSION >= 2) {
+                        // @ts-ignore
+                        migratedData.SlotsApplicable = 3;
+                    }
+                    // Ensure _version is updated on the data object itself
+                    // @ts-ignore
+                    migratedData._version = MIGRATIONS_CURRENT_VERSION;
+                    return [migratedData, MIGRATIONS_CURRENT_VERSION];
+                });
+        });
+
+        afterEach(() => {
+            migrateDataSpy.mockRestore();
+        });
+
+        it("should return default template for new data, migrated to current version", () => {
+            const newData = {};
+            // Data check always migrates to current version if _version is missing or old
+            const expectedData = {
+                ...dataService.template,
+                _version: require("shared/utils/migrations").migrations.CurrentVersion
+            };
+            // Account for migration from v1 (default template version) to current if applicable
+            // For example, if migration 1->2 adds SlotsApplicable, it should be present.
+            // This depends on what migrations run from version 1 of the template.
+            // Let's assume migration from v1 adds SlotsApplicable = 3 (as per DataService)
+            if (require("shared/utils/migrations").migrations.CurrentVersion >= 2 && dataService.template._version <= 1) {
+                 // @ts-ignore // Allow adding property for test
+                expectedData.SlotsApplicable = 3;
+            }
+            // Add other expected fields from migrations if template starts at v1 and current is higher
+
+            const result = dataService.dataCheck(newData);
+    expect(result).toEqual(expectedData); // Full check restored
+        });
+
+        it("should migrate old data and merge with template", () => {
+            const oldData = { _version: 1, oldField: "oldValue" };
+            // Assuming migration from version 1 adds SlotsApplicable = 3
+            const expectedData = {
+                ...dataService.template,
+                _version: require("shared/utils/migrations").migrations.CurrentVersion, // Use shared alias
+                SlotsApplicable: 3, // From migration 1 -> 2
+                oldField: "oldValue", // Extra fields should be preserved
+            };
+            const result = dataService.dataCheck(oldData);
+            expect(result).toEqual(expectedData);
+        });
+
+        it("should handle data with extra fields not in template, and migrate if version is old", () => {
+            // Template version is 1. Current version is 6.
+            const dataWithExtra = { ...dataService.template, _version: 1, extraField: "extraValue" };
+            const expectedData = {
+                ...dataService.template,
+                _version: require("shared/utils/migrations").migrations.CurrentVersion,
+                SlotsApplicable: 3, // From migration 1 -> 2
+                extraField: "extraValue",
+            };
+            const result = dataService.dataCheck(dataWithExtra);
+            expect(result).toEqual(expectedData);
+        });
+
+        it("should call migrations.migrateData if version is older", () => {
+            // Relies on migrateDataSpy from the describe block's beforeEach
+            const oldData = { _version: 1 };
+            dataService.dataCheck(oldData);
+            // The spy is already set up by beforeEach.
+            // The mockImplementation in beforeEach might not be what we want to test here,
+            // as we are testing IF it's called, not its mocked return.
+            // However, for this specific test, we just care it was called with correct args.
+            // The object passed is mutated by dataCheck, so we check the state AT THE TIME OF CALL.
+            // The first argument to the spy should be the dataTable as it was when migrateData was called.
+            expect(migrateDataSpy).toHaveBeenCalledWith(
+                expect.objectContaining({ _version: 1 }), // At the time of call, dataTable._version is 1
+                1
+            );
+            // No need to restore here, afterEach will handle it.
+        });
+    });
+
+    describe("Profile Operations", () => {
+        let mockPlayer: MockProxy<Player>;
+        let mockProfile: MockProxy<NonNullable<ReturnType<ReturnType<typeof ProfileStore.New>["StartSessionAsync"]>>>;
+
+        beforeEach(() => {
+            mockPlayer = mock<Player>();
+            mockPlayer.UserId = 123; // Example UserId
+            mockPlayer.DisplayName = "TestPlayer";
+            mockPlayer.Parent = mockPlayers; // Mock Player.Parent
+
+            mockProfile = mockDeep<NonNullable<ReturnType<ReturnType<typeof ProfileStore.New>["StartSessionAsync"]>>>();
+            mockProfile.Data = { ...dataService.template }; // Default data
+            mockProfile.OnSessionEnd = { Connect: jest.fn() } as any;
+
+
+            // Mock ProfileStore.StartSessionAsync to return the mockProfile
+            (mockProfileStore.StartSessionAsync as jest.Mock).mockResolvedValue(mockProfile);
+        });
+
+        describe("openDocument", () => {
+            it("should open a profile and store it", async () => {
+                const success = await dataService.openDocument(mockPlayer);
+                expect(success).toBe(true);
+                expect(mockProfileStore.StartSessionAsync).toHaveBeenCalledWith(
+                    `Player_${mockPlayer.UserId}`,
+                    expect.any(Object)
+                );
+                expect(mockProfile.AddUserId).toHaveBeenCalledWith(mockPlayer.UserId);
+                // Check if profile is stored (internal state, might need adjustment)
+                // expect(dataService.profiles.get(mockPlayer)).toBe(mockProfile);
+            });
+
+            it("should return false if player leaves before profile loads", async () => {
+                mockPlayer.Parent = undefined; // Simulate player leaving
+                const success = await dataService.openDocument(mockPlayer);
+                expect(success).toBe(false);
+                expect(mockProfile.EndSession).toHaveBeenCalled();
+            });
+        });
+
+        describe("getCache", () => {
+            it("should open document if profile not loaded and return data", async () => {
+                const data = await dataService.getCache(mockPlayer);
+                expect(mockProfileStore.StartSessionAsync).toHaveBeenCalled();
+                expect(data).toEqual(dataService.dataCheck({ ...dataService.template }));
+            });
+
+            it("should return existing profile data if already loaded", async () => {
+                // Pre-load profile
+                await dataService.openDocument(mockPlayer);
+                (mockProfileStore.StartSessionAsync as jest.Mock).mockClear(); // Clear previous calls
+
+                const data = await dataService.getCache(mockPlayer);
+                expect(mockProfileStore.StartSessionAsync).not.toHaveBeenCalled();
+                expect(data).toEqual(dataService.dataCheck({ ...dataService.template }));
+            });
+        });
+
+        describe("closeDocument", () => {
+            it("should end session if profile exists", async () => {
+                await dataService.openDocument(mockPlayer); // Ensure profile is loaded
+                dataService.closeDocument(mockPlayer);
+                expect(mockProfile.EndSession).toHaveBeenCalled();
+            });
+
+            it("should not throw if profile does not exist", () => {
+                expect(() => dataService.closeDocument(mockPlayer)).not.toThrow();
+            });
+        });
+    });
+
+    describe("setCache", () => {
+        let mockPlayer: MockProxy<Player>;
+        let mockProfile: MockProxy<NonNullable<ReturnType<ReturnType<typeof ProfileStore.New>["StartSessionAsync"]>>>;
+
+        beforeEach(async () => { // Made async to await openDocument
+            mockPlayer = mock<Player>();
+            mockPlayer.UserId = 456;
+            mockPlayer.DisplayName = "CacheSetter";
+            mockPlayer.Parent = mockPlayers;
+
+            mockProfile = mockDeep<NonNullable<ReturnType<ReturnType<typeof ProfileStore.New>["StartSessionAsync"]>>>();
+            mockProfile.Data = { ...dataService.template };
+            mockProfile.OnSessionEnd = { Connect: jest.fn() } as any;
+
+            (mockProfileStore.StartSessionAsync as jest.Mock).mockResolvedValue(mockProfile);
+            // Ensure profile is loaded before setCache is called
+            await dataService.openDocument(mockPlayer);
+        });
+
+        it("should set validated and optimized data to the profile", () => {
+            const newCache = {
+                ...dataService.template,
+                PlayerStatistics: {
+                    ...dataService.template.PlayerStatistics,
+                    Jumps: 100, // Changed value
+                },
+                AnotherField: "newValue", // New field
+            };
+
+            dataService.setCache(mockPlayer, newCache);
+
+            // Expect dataCheck to have been called (implicitly tested by checking optimizedData)
+            // Expect data to be optimized (default values removed, _version kept)
+            const expectedOptimizedData = {
+                _version: newCache._version, // Assuming _version is part of template or added by dataCheck
+                PlayerStatistics: {
+                    Jumps: 100,
+                },
+                AnotherField: "newValue",
+            };
+
+            // Need to access the internal profiles map for this check or spy on profile.Data assignment
+            // For simplicity, let's assume profile.Data was set correctly
+            // A more robust test would spy on `mockProfile.Data = ...`
+            // or retrieve the profile again and check its Data.
+            // However, direct assignment like `profile.Data = optimizedData` is hard to spy on directly with jest-mock-extended for properties.
+            // A workaround would be to make `profiles` map protected and access it in tests, or add a getter for testing.
+
+            // For now, we'll check the structure of what *should* be set.
+            // This relies on the internal logic of setCache.
+            const setData = mockProfile.Data; // This will be the data from beforeEach, not what was set
+                                          // This highlights a limitation in directly testing the assignment without spies or getters.
+
+            // To properly test this, we'd ideally spy on the assignment to `profile.Data`.
+            // Let's assume `dataCheck` and optimization logic are correct as tested elsewhere/implicitly.
+            // The main thing to check here is that `profile.Data` is updated.
+            // We can capture the argument passed to `profile.Data = ...` if we could spy on it.
+
+            // Since direct property assignment spying is tricky, we'll trust the internal logic
+            // and assume that if dataCheck is called, the optimization and assignment follow.
+            // A more integration-style test would be needed to fully verify the Data property update.
+
+            // We can at least check that dataCheck was implicitly part of the flow by its effect.
+            // If `dataCheck` wasn't called, `_version` might be missing or wrong.
+            // If optimization didn't happen, default values would persist.
+
+            // Let's spy on dataCheck to ensure it's part of the process
+            const dataCheckSpy = jest.spyOn(dataService, "dataCheck");
+            dataService.setCache(mockPlayer, { ...newCache }); // Re-call with a fresh object
+            expect(dataCheckSpy).toHaveBeenCalledWith(expect.objectContaining({ AnotherField: "newValue" }));
+            dataCheckSpy.mockRestore();
+
+            // And verify the profile data was indeed updated
+            // This requires the mockProfile.Data to be updated by the setCache method.
+            // The `mockProfile.Data = optimizedData as DataTemplate;` line in `setCache` should do this.
+            expect(mockProfile.Data.PlayerStatistics.Jumps).toBe(100);
+            expect((mockProfile.Data as any).AnotherField).toBe("newValue");
+             // Check if default values are stripped (e.g. if a value was same as template, it should be gone)
+            // Example: if 'Kills' was default and not in newCache, it shouldn't be in optimized data unless it's in template
+            // This part is harder to verify without knowing exact template defaults vs newCache.
+        });
+
+        it("should throw an error if profile is not found", () => {
+            const nonExistentPlayer = mock<Player>();
+            nonExistentPlayer.UserId = 789;
+            expect(() => dataService.setCache(nonExistentPlayer, dataService.template)).toThrow("Profile not found for player");
+        });
+    });
+
+    describe("Performance Methods", () => {
+        const performance = require("shared/utils/performance").performance; // Use shared alias
+        let getMetricsSpy: jest.SpyInstance;
+        let printReportSpy: jest.SpyInstance;
+
+        beforeEach(() => {
+            getMetricsSpy = jest.spyOn(performance, "getMetrics");
+            printReportSpy = jest.spyOn(performance, "printReport");
+        });
+
+        afterEach(() => {
+            getMetricsSpy.mockRestore();
+            printReportSpy.mockRestore();
+        });
+
+        describe("getPerformanceMetrics", () => {
+            it("should call performance.getMetrics and return its result", () => {
+                const mockMetrics = { totalTime: 100, operations: 5 };
+                getMetricsSpy.mockReturnValue(mockMetrics);
+
+                const result = dataService.getPerformanceMetrics();
+                expect(getMetricsSpy).toHaveBeenCalledTimes(1);
+                expect(result).toEqual(mockMetrics);
+            });
+        });
+
+        describe("printPerformanceReport", () => {
+            it("should call performance.printReport", () => {
+                dataService.printPerformanceReport();
+                expect(printReportSpy).toHaveBeenCalledTimes(1);
+            });
+        });
+    });
+});

--- a/scripts/js/jest-empty-mock.js
+++ b/scripts/js/jest-empty-mock.js
@@ -1,0 +1,2 @@
+// Empty mock for non-JS files
+module.exports = {};

--- a/scripts/js/jest-flamework-mock.js
+++ b/scripts/js/jest-flamework-mock.js
@@ -1,0 +1,23 @@
+// Mock for @flamework/core
+// For Jest tests in Node.js environment
+
+// Mock the Service decorator
+// It's a class decorator, so it needs to return a new constructor or the original one.
+// For simplicity, we'll make it an identity decorator.
+const Service = () => (ctor) => ctor;
+
+// Mock the OnInit interface/decorator if used as such (though it's usually an interface)
+// If OnInit is just an interface, it doesn't need a runtime mock unless used in a way that requires it.
+// Assuming it's primarily for type checking.
+const OnInit = {}; // Placeholder, might not be strictly necessary as a runtime mock
+
+// Mock other decorators or functions if they are used and cause errors
+// e.g., OnStart, Dependency, etc.
+
+module.exports = {
+    Service,
+    OnInit,
+    // Add other exports from @flamework/core if they are directly used and need mocking
+    // For example, if Dependency decorator is used:
+    // Dependency: () => () => {},
+};

--- a/scripts/js/jest-profile-store-mock.js
+++ b/scripts/js/jest-profile-store-mock.js
@@ -1,0 +1,16 @@
+// Mock for @rbxts/profile-store
+// This is used to prevent Jest from trying to load/parse .lua files.
+// The actual detailed mocking is done in the test file.
+
+const ProfileStore = {
+    New: jest.fn(() => ({
+        StartSessionAsync: jest.fn(),
+        Mock: { // If DataService uses .Mock in IsStudio()
+            StartSessionAsync: jest.fn(),
+        },
+        // Add any other methods or properties that might be accessed
+        // by the code under test before the test-specific mock takes over.
+    })),
+};
+
+module.exports = ProfileStore;

--- a/scripts/js/jest-rbxts-services-mock.js
+++ b/scripts/js/jest-rbxts-services-mock.js
@@ -1,0 +1,48 @@
+// Mock for @rbxts/services
+// Provides basic stubs for services used in tests.
+// The actual detailed mocking is often done within the test files themselves
+// using jest.mock() or jest-mock-extended.
+
+const Players = {
+    // Add any properties or methods that are accessed directly
+    // by the code under test if not covered by test-specific mocks.
+    // Example: Players.PlayerAdded, Players.GetPlayerByUserId(), etc.
+    // For now, a simple object will do to satisfy the import.
+    PlayerAdded: {
+        Connect: () => {},
+        Disconnect: () => {},
+    },
+    PlayerRemoving: {
+        Connect: () => {},
+        Disconnect: () => {},
+    },
+    GetPlayerByUserId: (userId) => undefined,
+    GetPlayers: () => [],
+};
+
+const RunService = {
+    // Example: RunService.IsStudio, RunService.Heartbeat
+    // IsStudio: () => false, // Default mock value
+    // IsClient: () => false,
+    // IsServer: () => true,
+    // Heartbeat: {
+    //     Connect: () => {},
+    //     Disconnect: () => {},
+    // },
+    // Stepped: {
+    //     Connect: () => {},
+    //     Disconnect: () => {},
+    // },
+};
+
+// Add other services if they are imported and used from @rbxts/services
+// e.g. ReplicatedStorage, ServerScriptService, etc.
+
+// Use jest-mock-extended directly in the file mock
+const { mock } = require('jest-mock-extended');
+
+module.exports = {
+    Players: mock(),
+    RunService: mock(),
+    // Add other exported services here, also as mock()
+};

--- a/scripts/js/jest-setup-roblox-mocks.js
+++ b/scripts/js/jest-setup-roblox-mocks.js
@@ -33,3 +33,122 @@ global.workspace = {
 global.wait = (time) => {
 	return new Promise(resolve => setTimeout(resolve, (time || 0) * 1000));
 };
+
+// Mock 'print'
+global.print = jest.fn((...args) => {
+    // console.log(...args); // Optionally log to Jest console
+});
+
+// Mock 'tick'
+global.tick = jest.fn(() => {
+    return Date.now() / 1000; // Return seconds like Roblox's tick()
+});
+
+// Mock 'task' library (for task.spawn, task.defer, etc.)
+global.task = {
+    spawn: jest.fn((func, ...args) => {
+        // In a test environment, we might want to execute immediately
+        // or provide a way to control execution if testing async logic.
+        // For simplicity, let's try immediate execution.
+        try {
+            if (typeof func === "function") func(...args);
+        } catch (e) {
+            // console.error("Error in task.spawn mock:", e);
+        }
+    }),
+    defer: jest.fn((func, ...args) => {
+        // Similar to spawn, could be immediate or controlled.
+        // Make defer synchronous for simpler test execution
+        if (typeof func === "function") func(...args);
+    }),
+    wait: jest.fn((seconds) => Promise.resolve()), // Waits resolve immediately
+    // Add other task functions if needed e.g. task.cancel
+    cancel: jest.fn(),
+};
+
+// Mock 'coroutine' library (if used directly, though task is more common now)
+// DataService uses coroutine.running() and coroutine.yield() via coroutine.resume()
+global.coroutine = {
+    running: jest.fn(() => ({ type: "mockThread" })), // Return an identifiable mock thread
+    resume: jest.fn((thread, ...args) => [true]), // Assume success, no real execution
+    yield: jest.fn(() => []), // Yield immediately returns, no actual async pause
+    create: jest.fn(f => {
+        const co = {
+            _f: f,
+            _args: [], // Removed 'as any[]'
+            _status: "suspended",
+            resume: function(...args) { // Removed ': any[]'
+                if (this._status === "dead") return [false, "cannot resume dead coroutine"];
+                this._status = "running";
+                try {
+                    const result = this._f(...args); // Execute the function
+                    this._status = "dead";
+                    return [true, result];
+                } catch (e) {
+                    this._status = "dead";
+                    return [false, e];
+                }
+            }
+        };
+        return co;
+    }),
+    wrap: jest.fn(f => {
+        const co = global.coroutine.create(f);
+        return (...args) => { // Removed ': any[]'
+            const result = co.resume(...args);
+            if (!result[0]) throw result[1]; // Throw error if resume failed
+            return result[1]; // Return the actual result
+        };
+    }),
+    status: jest.fn((co) => (co as any)?._status ?? "suspended"), // Default status
+};
+
+// Mock assert
+global.assert = jest.fn((condition, message) => {
+    if (!condition) {
+        throw new Error(message || "Assertion failed");
+    }
+});
+
+// Mock pairs (used in DataService for iterating over tables)
+global.pairs = jest.fn((obj) => {
+    if (typeof obj !== 'object' || obj === null) {
+        // Roblox `pairs` would error on non-tables (nil, boolean, etc.)
+        // For simplicity in mock, return empty or could throw.
+        // Matching error behavior might be too complex for mock.
+        return [];
+    }
+    if (Array.isArray(obj)) {
+        // Simulate Lua's 1-based indexing for arrays if obj is a JS array
+        return obj.map((value, index) => [index + 1, value]);
+    }
+    // For plain objects, Object.entries is a good equivalent
+    return Object.entries(obj);
+});
+
+// Mock typeOf (used in DataService)
+global.typeOf = jest.fn((value) => {
+    const jsType = typeof value;
+    if (value === null) return "nil"; // Roblox `nil` is like JS `null`
+    if (jsType === "undefined") return "nil";
+    if (jsType === "object") {
+        if (Array.isArray(value)) return "table"; // Roblox arrays are tables
+        return "table"; // Roblox objects are tables
+    }
+    if (jsType === "function") return "function";
+    if (jsType === "string") return "string";
+    if (jsType === "number") return "number";
+    if (jsType === "boolean") return "boolean";
+    return jsType; // Fallback, should cover most cases
+});
+
+// Mock math.floor (used in DataService migrations)
+global.math = {
+    ...global.math, // Preserve existing math functions if any
+    floor: jest.fn(Math.floor),
+};
+
+// Mock 'warn'
+global.warn = jest.fn((...args) => {
+    // console.warn(...args); // Optionally log to Jest console
+});

--- a/scripts/js/jest-transformer.js
+++ b/scripts/js/jest-transformer.js
@@ -5,6 +5,13 @@ const path = require("path");
 
 // Transform Roblox-TS test files to Node.js compatible Jest tests
 function process(sourceText, sourcePath) {
+	// Guard: Only process test/spec files
+	if (!/\.test\.ts$|\.spec\.ts$|__tests__/.test(sourcePath)) {
+		return {
+			code: sourceText,
+			map: null, // Source maps not needed for our use case
+		};
+	}
 	// Replace Roblox-TS Jest imports with standard Jest globals
 	let transformedSource = sourceText
 		.replace(/import\s+\{[^}]*\}\s+from\s+["']@rbxts\/jest-globals["'];?/g, "")

--- a/scripts/js/jest-transformer.js
+++ b/scripts/js/jest-transformer.js
@@ -5,14 +5,6 @@ const path = require("path");
 
 // Transform Roblox-TS test files to Node.js compatible Jest tests
 function process(sourceText, sourcePath) {
-	// If this is not a test file, return as-is (but still as an object with code property)
-	if (!sourcePath.includes("test") && !sourcePath.includes("spec")) {
-		return {
-			code: sourceText,
-			map: null,
-		};
-	}
-
 	// Replace Roblox-TS Jest imports with standard Jest globals
 	let transformedSource = sourceText
 		.replace(/import\s+\{[^}]*\}\s+from\s+["']@rbxts\/jest-globals["'];?/g, "")


### PR DESCRIPTION
Sets up Jest tests for DataService.ts and works through numerous environment and mocking issues to get tests running in a Node.js environment.

Key changes and steps taken:
1.  Created `places/common/src/tests/data.service.spec.ts` with Jest tests covering public methods of `DataService`.
2.  Configured Jest (`jest.config.js`) for TypeScript transformation and module resolution:
    *   Ensured the custom transformer (`scripts/js/jest-transformer.js`) processes all TS files, not just test files.
    *   Added `moduleNameMapper` entries for path aliases (`common/`, `server/`, `shared/`).
    *   Created file-level mocks for `@flamework/core`, `@rbxts/services`, and `@rbxts/profile-store` via `moduleNameMapper` because their `package.json:main` pointed to `.lua` files not parsable by Node/Jest. These mocks use `jest-mock-extended` internally.
3.  Installed missing `jest-mock-extended` and `typescript` dev dependencies.
4.  Populated `scripts/js/jest-setup-roblox-mocks.js` with global mocks for Roblox-specific functions like `print`, `warn`, `tick`, `task`, `coroutine`, `assert`, `pairs`, `typeOf`, and `math.floor`. This resolved many `ReferenceError`s.
5.  Corrected the `deepCopy` utility (`places/common/src/shared/utils/deep-copy.ts`) to properly handle arrays, preventing them from being converted to objects during data operations.
6.  Refined `DataService.deepMergeWithTemplate` to better handle type mismatches (array vs. object) between user data and template data.
7.  Mocked `migrations.migrateData` within the `dataCheck` test suite in `data.service.spec.ts` to isolate `dataCheck`'s logic. This allowed the core `dataCheck` validation and merge tests to pass.

Current Test Status: 9 tests passing, 7 failing.

Remaining Challenges & Why I'm Stuck:
1.  **`toHaveBeenCalledWith` failure in a `dataCheck` test**: One test checking if `migrations.migrateData` is called with specific arguments is failing. This seems to be a complex interaction with Jest's argument comparison for objects that are mutated by the function under test. The mock for `migrations.migrateData` itself works for other `dataCheck` tests.
2.  **`Profile Operations` and `setCache` test failures**: All tests related to `openDocument`, `getCache`, `closeDocument`, and `setCache` are failing. Errors indicate that `openDocument` is not behaving as expected (e.g., returning `false` instead of `true`, profiles not being found). This is likely due to the current simplified mocks for Roblox's asynchronous features (`task` and `coroutine`, especially `coroutine.yield` and `resume` logic used in `waitForPersonSessionEndedAsync`). The current mocks in `jest-setup-roblox-mocks.js` make async operations like `task.defer`, `task.spawn`, and `task.wait` synchronous or immediately resolving, which might not correctly simulate the timing or yielding behavior `DataService` relies on, particularly for its Promise-based session management. Fully replicating Roblox's coroutine scheduler and task library in a Node.js Jest environment is complex and is the primary blocker for these tests.

Further work would require more sophisticated async mocking or running tests in an environment closer to Roblox (like the originally intended cloud tests, which faced `rokit` setup issues in this sandbox).